### PR TITLE
Fixed typings to allow children in Typescript

### DIFF
--- a/packages/ant-design-draggable-modal/src/DraggableModal.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ReactElement, useContext } from 'react'
+import {FunctionComponent, ReactElement, useContext} from 'react'
 import { useUID } from 'react-uid'
 import { DraggableModalContext } from './DraggableModalContext'
 import { DraggableModalInner } from './DraggableModalInner'
@@ -7,9 +7,9 @@ import { getModalState } from './draggableModalReducer'
 import { ModalProps } from 'antd/lib/modal'
 import './DraggableModal.css'
 
-export type DraggableModalProps = ModalProps & { children?: string | ReactElement | ReactElement[] }
+export type DraggableModalProps = ModalProps;
 
-export const DraggableModal = (props: DraggableModalProps): React.ReactElement => {
+export const DraggableModal: FunctionComponent<DraggableModalProps> = (props: DraggableModalProps): React.ReactElement => {
     // Get the unique ID of this modal.
     const id = useUID()
 

--- a/packages/ant-design-draggable-modal/src/DraggableModal.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {FunctionComponent, ReactElement, useContext} from 'react'
+import { FunctionComponent, ReactElement, useContext } from 'react'
 import { useUID } from 'react-uid'
 import { DraggableModalContext } from './DraggableModalContext'
 import { DraggableModalInner } from './DraggableModalInner'
@@ -7,9 +7,11 @@ import { getModalState } from './draggableModalReducer'
 import { ModalProps } from 'antd/lib/modal'
 import './DraggableModal.css'
 
-export type DraggableModalProps = ModalProps;
+export type DraggableModalProps = ModalProps
 
-export const DraggableModal: FunctionComponent<DraggableModalProps> = (props: DraggableModalProps): React.ReactElement => {
+export const DraggableModal: FunctionComponent<DraggableModalProps> = (
+    props: DraggableModalProps,
+): ReactElement => {
     // Get the unique ID of this modal.
     const id = useUID()
 

--- a/packages/ant-design-draggable-modal/src/DraggableModal.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useContext } from 'react'
+import { ReactElement, useContext } from 'react'
 import { useUID } from 'react-uid'
 import { DraggableModalContext } from './DraggableModalContext'
 import { DraggableModalInner } from './DraggableModalInner'
@@ -7,7 +7,7 @@ import { getModalState } from './draggableModalReducer'
 import { ModalProps } from 'antd/lib/modal'
 import './DraggableModal.css'
 
-export type DraggableModalProps = ModalProps
+export type DraggableModalProps = ModalProps & { children?: string | ReactElement | ReactElement[] }
 
 export const DraggableModal = (props: DraggableModalProps): React.ReactElement => {
     // Get the unique ID of this modal.


### PR DESCRIPTION
Addresses the issue mentioned in #9 by just adding a TypeScript type of `FunctionComponent` for the DraggableModal component to ensure that it will accept child elements.