### PR TITLE
Added initialX and initialY.

### DIFF
--- a/packages/ant-design-draggable-modal/src/DraggableModal.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModal.tsx
@@ -9,6 +9,8 @@ import { ModalProps } from 'antd/lib/modal'
 export interface DraggableModalProps extends ModalProps {
     initialWidth?: number
     initialHeight?: number
+    initialX?: number
+    initialY?: number
 }
 
 export const DraggableModal: FunctionComponent<DraggableModalProps> = (
@@ -29,6 +31,8 @@ export const DraggableModal: FunctionComponent<DraggableModalProps> = (
         id,
         initialHeight: props.initialHeight,
         initialWidth: props.initialWidth,
+        initialX: props.initialX,
+        initialY: props.initialY,
     })
 
     // We do this so that we don't re-render all modals for every state change.

--- a/packages/ant-design-draggable-modal/src/DraggableModal.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModal.tsx
@@ -11,7 +11,6 @@ export interface DraggableModalProps extends ModalProps {
     initialHeight?: number
     initialX?: number
     initialY?: number
-    resizable?: boolean
 }
 
 export const DraggableModal: FunctionComponent<DraggableModalProps> = (

--- a/packages/ant-design-draggable-modal/src/DraggableModal.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModal.tsx
@@ -11,6 +11,7 @@ export interface DraggableModalProps extends ModalProps {
     initialHeight?: number
     initialX?: number
     initialY?: number
+    resizable?: boolean
 }
 
 export const DraggableModal: FunctionComponent<DraggableModalProps> = (

--- a/packages/ant-design-draggable-modal/src/DraggableModalInner.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModalInner.tsx
@@ -18,7 +18,6 @@ interface ContextProps extends DraggableModalContextMethods {
     initialHeight?: number
     initialX?: number
     initialY?: number
-    resizable?: boolean
 }
 
 export type DraggableModalInnerProps = ModalProps & { children?: React.ReactNode } & ContextProps
@@ -34,7 +33,6 @@ function DraggableModalInnerNonMemo({
     initialHeight,
     initialX,
     initialY,
-    resizable = true,
     ...otherProps
 }: DraggableModalInnerProps) {
     // Call on mount and unmount.
@@ -57,7 +55,7 @@ function DraggableModalInnerNonMemo({
 
     const { zIndex, x, y, width, height } = modalState
 
-    const style: React.CSSProperties = useMemo(() => ({ ...modalStyle, top: y, left: x, height: resizable ? height : 'auto' }), [
+    const style: React.CSSProperties = useMemo(() => ({ ...modalStyle, top: y, left: x, height }), [
         y,
         x,
         height,
@@ -95,7 +93,7 @@ function DraggableModalInnerNonMemo({
         <Modal
             wrapClassName="ant-design-draggable-modal"
             style={style}
-            width={resizable ? width : undefined}
+            width={width}
             destroyOnClose={true}
             mask={false}
             maskClosable={false}
@@ -105,7 +103,7 @@ function DraggableModalInnerNonMemo({
             {...otherProps}
         >
             {children}
-            {resizable && <ResizeHandle onMouseDown={onMouseResize} />}
+            <ResizeHandle onMouseDown={onMouseResize} />
         </Modal>
     )
 }

--- a/packages/ant-design-draggable-modal/src/DraggableModalInner.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModalInner.tsx
@@ -16,6 +16,8 @@ interface ContextProps extends DraggableModalContextMethods {
     modalState: ModalState
     initialWidth?: number
     initialHeight?: number
+    initialX?: number
+    initialY?: number
 }
 
 export type DraggableModalInnerProps = ModalProps & { children?: React.ReactNode } & ContextProps
@@ -29,11 +31,13 @@ function DraggableModalInnerNonMemo({
     title,
     initialWidth,
     initialHeight,
+    initialX,
+    initialY,
     ...otherProps
 }: DraggableModalInnerProps) {
     // Call on mount and unmount.
     useEffect(() => {
-        dispatch({ type: 'mount', id, intialState: { initialWidth, initialHeight } })
+        dispatch({ type: 'mount', id, intialState: { initialWidth, initialHeight, initialX, initialY } })
         return () => dispatch({ type: 'unmount', id })
     }, [dispatch, id, initialWidth, initialHeight])
 

--- a/packages/ant-design-draggable-modal/src/DraggableModalInner.tsx
+++ b/packages/ant-design-draggable-modal/src/DraggableModalInner.tsx
@@ -18,6 +18,7 @@ interface ContextProps extends DraggableModalContextMethods {
     initialHeight?: number
     initialX?: number
     initialY?: number
+    resizable?: boolean
 }
 
 export type DraggableModalInnerProps = ModalProps & { children?: React.ReactNode } & ContextProps
@@ -33,6 +34,7 @@ function DraggableModalInnerNonMemo({
     initialHeight,
     initialX,
     initialY,
+    resizable = true,
     ...otherProps
 }: DraggableModalInnerProps) {
     // Call on mount and unmount.
@@ -55,7 +57,7 @@ function DraggableModalInnerNonMemo({
 
     const { zIndex, x, y, width, height } = modalState
 
-    const style: React.CSSProperties = useMemo(() => ({ ...modalStyle, top: y, left: x, height }), [
+    const style: React.CSSProperties = useMemo(() => ({ ...modalStyle, top: y, left: x, height: resizable ? height : 'auto' }), [
         y,
         x,
         height,
@@ -93,7 +95,7 @@ function DraggableModalInnerNonMemo({
         <Modal
             wrapClassName="ant-design-draggable-modal"
             style={style}
-            width={width}
+            width={resizable ? width : undefined}
             destroyOnClose={true}
             mask={false}
             maskClosable={false}
@@ -103,7 +105,7 @@ function DraggableModalInnerNonMemo({
             {...otherProps}
         >
             {children}
-            <ResizeHandle onMouseDown={onMouseResize} />
+            {resizable && <ResizeHandle onMouseDown={onMouseResize} />}
         </Modal>
     )
 }


### PR DESCRIPTION
Added `initialX` and `initialY` props. With these changes it always remembers last position and next time modal window will be opened with previous `x` and `y` (in master modal window always opens in the browser center) - not sure how critical is this.